### PR TITLE
Add iOS smart plant pot app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # codex
+
+This repository contains a sample iOS application to manage a smart plant pot.
+The project `SmartPlantPotApp` demonstrates a simple SwiftUI interface that
+allows:
+
+- Basic login screen (no real authentication logic implemented).
+- Listing and adding plants with optional photo-based identification (stubbed).
+- Managing locations for plants (rooms, office, etc.).
+- Viewing plant details with current sensor values compared to ideal ranges.
+
+The app includes placeholder areas where integration with the ChatGPT API and
+sensor devices should be implemented.

--- a/SmartPlantPotApp/AddPlantView.swift
+++ b/SmartPlantPotApp/AddPlantView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct AddPlantView: View {
+    @Binding var plants: [Plant]
+    @State private var species: String = ""
+    @State private var nickname: String = ""
+    @State private var showImagePicker: Bool = false
+    @State private var image: UIImage?
+
+    var body: some View {
+        Form {
+            TextField("Species", text: $species)
+            TextField("Nickname", text: $nickname)
+            Button("Identify from Photo") {
+                showImagePicker = true
+            }
+            if let image = image {
+                Image(uiImage: image).resizable().scaledToFit()
+            }
+            Button("Save") {
+                let plant = Plant(species: species, nickname: nickname.isEmpty ? nil : nickname, idealLight: nil, idealSoilHumidity: nil, idealTemperature: nil, idealAirHumidity: nil)
+                plants.append(plant)
+            }
+        }
+        .sheet(isPresented: $showImagePicker) {
+            ImagePicker(image: $image, onImagePicked: identifyPlant)
+        }
+    }
+
+    func identifyPlant(image: UIImage) {
+        // TODO: call ChatGPT API to identify plant and fetch ideal conditions
+    }
+}
+
+struct AddPlantView_Previews: PreviewProvider {
+    static var previews: some View {
+        AddPlantView(plants: .constant([]))
+    }
+}

--- a/SmartPlantPotApp/DashboardView.swift
+++ b/SmartPlantPotApp/DashboardView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct DashboardView: View {
+    @State private var plants: [Plant] = []
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(plants) { plant in
+                    NavigationLink(destination: PlantDetailView(plant: plant)) {
+                        Text(plant.displayName)
+                    }
+                }
+            }
+            .navigationTitle("My Plants")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    NavigationLink(destination: AddPlantView(plants: $plants)) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct DashboardView_Previews: PreviewProvider {
+    static var previews: some View {
+        DashboardView()
+    }
+}

--- a/SmartPlantPotApp/ImagePicker.swift
+++ b/SmartPlantPotApp/ImagePicker.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+import UIKit
+
+struct ImagePicker: UIViewControllerRepresentable {
+    @Environment(\.presentationMode) private var presentationMode
+    @Binding var image: UIImage?
+    var onImagePicked: (UIImage) -> Void
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.delegate = context.coordinator
+        picker.sourceType = .photoLibrary
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        let parent: ImagePicker
+        init(_ parent: ImagePicker) { self.parent = parent }
+
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let uiImage = info[.originalImage] as? UIImage {
+                parent.image = uiImage
+                parent.onImagePicked(uiImage)
+            }
+            parent.presentationMode.wrappedValue.dismiss()
+        }
+    }
+}

--- a/SmartPlantPotApp/LocationManagementView.swift
+++ b/SmartPlantPotApp/LocationManagementView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct LocationManagementView: View {
+    @State private var locations: [Location] = []
+    @State private var newLocationName: String = ""
+
+    var body: some View {
+        VStack {
+            List {
+                ForEach(locations) { location in
+                    Text(location.name)
+                }
+            }
+            HStack {
+                TextField("Add Location", text: $newLocationName)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Button("Add") {
+                    let location = Location(name: newLocationName, areas: [])
+                    locations.append(location)
+                    newLocationName = ""
+                }
+            }.padding()
+        }
+        .navigationTitle("Locations")
+    }
+}
+
+struct LocationManagementView_Previews: PreviewProvider {
+    static var previews: some View {
+        LocationManagementView()
+    }
+}

--- a/SmartPlantPotApp/LoginView.swift
+++ b/SmartPlantPotApp/LoginView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct LoginView: View {
+    @State private var email: String = ""
+    @State private var password: String = ""
+    @State private var isLoggedIn: Bool = false
+
+    var body: some View {
+        if isLoggedIn {
+            DashboardView()
+        } else {
+            VStack {
+                Text("Smart Plant Pot").font(.largeTitle)
+                TextField("Email", text: $email)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding()
+                SecureField("Password", text: $password)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding()
+                Button("Login") {
+                    // TODO: Implement real authentication
+                    isLoggedIn = true
+                }
+                .padding()
+                Button("Sign Up") {
+                    // TODO: Implement sign up flow
+                }.padding()
+            }.padding()
+        }
+    }
+}
+
+struct LoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoginView()
+    }
+}

--- a/SmartPlantPotApp/Models.swift
+++ b/SmartPlantPotApp/Models.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct User: Identifiable {
+    let id = UUID()
+    var email: String
+    var password: String
+    var locations: [Location]
+}
+
+struct Location: Identifiable {
+    let id = UUID()
+    var name: String
+    var areas: [Area]
+}
+
+struct Area: Identifiable {
+    let id = UUID()
+    var name: String
+    var plants: [Plant]
+}
+
+struct Plant: Identifiable {
+    let id = UUID()
+    var species: String
+    var nickname: String?
+    var idealLight: Double?
+    var idealSoilHumidity: Double?
+    var idealTemperature: Double?
+    var idealAirHumidity: Double?
+}
+
+extension Plant {
+    var displayName: String { nickname ?? species }
+}

--- a/SmartPlantPotApp/PlantDetailView.swift
+++ b/SmartPlantPotApp/PlantDetailView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct PlantDetailView: View {
+    var plant: Plant
+    @State private var currentLight: Double?
+    @State private var currentSoilHumidity: Double?
+    @State private var currentTemperature: Double?
+    @State private var currentAirHumidity: Double?
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(plant.displayName).font(.title)
+            if let ideal = plant.idealLight {
+                HStack {
+                    Text("Light: \(currentLight ?? 0, specifier: "%.1f") / \(ideal, specifier: "%.1f")")
+                    alertIcon(current: currentLight, ideal: ideal)
+                }
+            }
+            if let ideal = plant.idealSoilHumidity {
+                HStack {
+                    Text("Soil Humidity: \(currentSoilHumidity ?? 0, specifier: "%.1f") / \(ideal, specifier: "%.1f")")
+                    alertIcon(current: currentSoilHumidity, ideal: ideal)
+                }
+            }
+            if let ideal = plant.idealTemperature {
+                HStack {
+                    Text("Temperature: \(currentTemperature ?? 0, specifier: "%.1f") / \(ideal, specifier: "%.1f")")
+                    alertIcon(current: currentTemperature, ideal: ideal)
+                }
+            }
+            if let ideal = plant.idealAirHumidity {
+                HStack {
+                    Text("Air Humidity: \(currentAirHumidity ?? 0, specifier: "%.1f") / \(ideal, specifier: "%.1f")")
+                    alertIcon(current: currentAirHumidity, ideal: ideal)
+                }
+            }
+            Spacer()
+        }
+        .padding()
+        .onAppear {
+            // TODO: load sensor values
+        }
+    }
+
+    func alertIcon(current: Double?, ideal: Double) -> some View {
+        if let current = current {
+            if current < ideal * 0.9 {
+                return Image(systemName: "arrow.down.circle").foregroundColor(.blue)
+            } else if current > ideal * 1.1 {
+                return Image(systemName: "arrow.up.circle").foregroundColor(.red)
+            }
+        }
+        return Image(systemName: "checkmark.circle").foregroundColor(.green)
+    }
+}
+
+struct PlantDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        PlantDetailView(plant: Plant(species: "Ficus", nickname: "My Plant", idealLight: 5, idealSoilHumidity: 40, idealTemperature: 22, idealAirHumidity: 60))
+    }
+}

--- a/SmartPlantPotApp/SmartPlantPotApp.swift
+++ b/SmartPlantPotApp/SmartPlantPotApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct SmartPlantPotApp: App {
+    var body: some Scene {
+        WindowGroup {
+            LoginView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- set up README for the new sample app
- add SwiftUI project skeleton in `SmartPlantPotApp`
- implement simple login, dashboard, plant management, and location management views
- add placeholder image picker and plant detail views

## Testing
- `swift --version`
- `swiftc SmartPlantPotApp/*.swift -o smartapp` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68471c50883483289a1aa2737a75b2d5