### PR TITLE
Add improved IoT example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# codex
+# Codex IoT Example
+
+This repository provides a simple Python script that publishes sensor data to **AWS IoT** and stores the same data in **Amazon DynamoDB**.
+
+## Files
+
+- `iot/sensor_device.py` - Example script that generates fake sensor readings, publishes them over MQTT and writes them to DynamoDB.
+
+## Requirements
+
+- Python 3
+- `aws-iot-device-sdk-python-v2` and `boto3`
+- AWS IoT certificates and endpoint
+- DynamoDB table already created
+
+## Usage
+
+Export the following environment variables with your configuration:
+
+```
+export AWS_IOT_ENDPOINT="xxxxxxxxxxxxx-ats.iot.us-east-1.amazonaws.com"
+export AWS_IOT_CERT="/path/to/certificate.pem.crt"
+export AWS_IOT_KEY="/path/to/private.pem.key"
+export AWS_IOT_CA="/path/to/AmazonRootCA1.pem"
+export AWS_IOT_CLIENT_ID="device001"
+export AWS_IOT_TOPIC="sensors/data"
+export AWS_DYNAMO_TABLE="SensorData"
+export AWS_REGION="us-east-1"
+```
+
+Install the dependencies and run the script:
+
+```
+pip install aws-iot-device-sdk-python-v2 boto3
+python3 iot/sensor_device.py
+```
+
+The script will generate and send a sample payload every five seconds.

--- a/iot/sensor_device.py
+++ b/iot/sensor_device.py
@@ -1,0 +1,88 @@
+import json
+import os
+import time
+import random
+from dataclasses import dataclass
+from awscrt import mqtt
+from awsiot import mqtt_connection_builder
+import boto3
+
+
+def build_payload(sensor_id: str) -> dict:
+    """Return a fake sensor payload."""
+    return {
+        "sensor_id": sensor_id,
+        "timestamp": int(time.time()),
+        "temperature": round(random.uniform(20.0, 30.0), 2),
+        "humidity": round(random.uniform(30.0, 60.0), 2),
+    }
+
+
+@dataclass
+class IoTConfig:
+    endpoint: str
+    cert: str
+    key: str
+    ca: str
+    client_id: str
+    topic: str
+
+
+@dataclass
+class DynamoConfig:
+    table_name: str
+    region: str
+
+
+def mqtt_connect(cfg: IoTConfig):
+    connection = mqtt_connection_builder.mtls_from_path(
+        endpoint=cfg.endpoint,
+        port=8883,
+        cert_filepath=cfg.cert,
+        pri_key_filepath=cfg.key,
+        client_id=cfg.client_id,
+        ca_filepath=cfg.ca,
+        clean_session=False,
+        keep_alive_secs=30,
+    )
+    connection.connect().result()
+    return connection
+
+
+def dynamo_table(cfg: DynamoConfig):
+    session = boto3.session.Session()
+    return session.resource("dynamodb", region_name=cfg.region).Table(cfg.table_name)
+
+
+def publish_loop(sensor_id: str, mqtt_client, table, topic: str):
+    while True:
+        payload = build_payload(sensor_id)
+        mqtt_client.publish(topic=topic, payload=json.dumps(payload), qos=mqtt.QoS.AT_LEAST_ONCE)
+        table.put_item(Item=payload)
+        print(f"Published and stored: {payload}")
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    iot_cfg = IoTConfig(
+        endpoint=os.environ["AWS_IOT_ENDPOINT"],
+        cert=os.environ["AWS_IOT_CERT"],
+        key=os.environ["AWS_IOT_KEY"],
+        ca=os.environ["AWS_IOT_CA"],
+        client_id=os.environ.get("AWS_IOT_CLIENT_ID", "device001"),
+        topic=os.environ.get("AWS_IOT_TOPIC", "sensors/data"),
+    )
+
+    dynamo_cfg = DynamoConfig(
+        table_name=os.environ["AWS_DYNAMO_TABLE"],
+        region=os.environ.get("AWS_REGION", "us-east-1"),
+    )
+
+    mqtt_client = mqtt_connect(iot_cfg)
+    table = dynamo_table(dynamo_cfg)
+
+    try:
+        publish_loop("sensor-1", mqtt_client, table, iot_cfg.topic)
+    except KeyboardInterrupt:
+        print("Stopping device...")
+        mqtt_client.disconnect().result()


### PR DESCRIPTION
## Summary
- rework README with ASCII-only documentation
- create new sensor example using environment variables for configuration
- publish sensor data to AWS IoT and store it in DynamoDB

## Testing
- `python3 -m py_compile iot/sensor_device.py`


------
https://chatgpt.com/codex/tasks/task_e_68471df6156c8328b0c46685ce0d0cda