### PR TITLE
Add device linking to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ allows:
 - Listing and adding plants with optional photo-based identification (stubbed).
 - Managing locations for plants (rooms, office, etc.).
 - Viewing plant details with current sensor values compared to ideal ranges.
+- Linking hardware devices to your user account.
 
 The app includes placeholder areas where integration with the ChatGPT API and
 sensor devices should be implemented.
+
+You can link a hardware sensor device to your account from the dashboard by
+selecting the **Devices** button and entering the device identifier.
 
 ## Google Sign-In setup
 

--- a/SmartPlantPotApp/AddDeviceView.swift
+++ b/SmartPlantPotApp/AddDeviceView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct AddDeviceView: View {
+    @Binding var devices: [Device]
+    @State private var name: String = ""
+    @State private var identifier: String = ""
+
+    var body: some View {
+        Form {
+            TextField("Device Name", text: $name)
+            TextField("Identifier", text: $identifier)
+            Button("Save") {
+                let device = Device(name: name, identifier: identifier)
+                devices.append(device)
+            }
+        }
+        .navigationTitle("Add Device")
+    }
+}
+
+struct AddDeviceView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            AddDeviceView(devices: .constant([]))
+        }
+    }
+}

--- a/SmartPlantPotApp/DashboardView.swift
+++ b/SmartPlantPotApp/DashboardView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct DashboardView: View {
     @State private var plants: [Plant] = []
+    @State private var devices: [Device] = []
 
     var body: some View {
         NavigationView {
@@ -14,6 +15,11 @@ struct DashboardView: View {
             }
             .navigationTitle("My Plants")
             .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    NavigationLink(destination: DeviceManagementView(devices: $devices)) {
+                        Image(systemName: "bolt.horizontal" )
+                    }
+                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     NavigationLink(destination: AddPlantView(plants: $plants)) {
                         Image(systemName: "plus")

--- a/SmartPlantPotApp/DeviceManagementView.swift
+++ b/SmartPlantPotApp/DeviceManagementView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct DeviceManagementView: View {
+    @Binding var devices: [Device]
+
+    var body: some View {
+        List {
+            ForEach(devices) { device in
+                Text(device.name)
+            }
+        }
+        .navigationTitle("Devices")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                NavigationLink(destination: AddDeviceView(devices: $devices)) {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+    }
+}
+
+struct DeviceManagementView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            DeviceManagementView(devices: .constant([]))
+        }
+    }
+}

--- a/SmartPlantPotApp/Models.swift
+++ b/SmartPlantPotApp/Models.swift
@@ -5,6 +5,17 @@ struct User: Identifiable {
     var email: String
     var password: String
     var locations: [Location]
+    /// Devices linked to this user account
+    var devices: [Device]
+}
+
+/// Represents a physical sensor device that can upload data for the user.
+struct Device: Identifiable {
+    let id = UUID()
+    /// Friendly name chosen by the user
+    var name: String
+    /// Unique identifier from the hardware (e.g. serial number)
+    var identifier: String
 }
 
 struct Location: Identifiable {


### PR DESCRIPTION
## Summary
- support linking hardware devices to user accounts
- provide new views for adding and managing devices
- expose device management from the dashboard
- document device linking in README

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684761a2db6c832891bd8b497985ee3a