### PR TITLE
Add device linking to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ allows:
 - Listing and adding plants with optional photo-based identification (stubbed).
 - Managing locations for plants (rooms, office, etc.).
 - Viewing plant details with current sensor values compared to ideal ranges.
+- Linking hardware devices to your user account.
 
 The app includes placeholder areas where integration with the ChatGPT API and
 sensor devices should be implemented.
+
+You can link a hardware sensor device to your account from the dashboard by
+selecting the **Devices** button and entering the device identifier.
 
 ## Google Sign-In setup
 

--- a/SmartPlantPotApp/AddDeviceView.swift
+++ b/SmartPlantPotApp/AddDeviceView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct AddDeviceView: View {
+    @EnvironmentObject var session: UserSession
+    @State private var name: String = ""
+    @State private var identifier: String = ""
+
+    var body: some View {
+        Form {
+            TextField("Device Name", text: $name)
+            TextField("Identifier", text: $identifier)
+            Button("Save") {
+                let device = Device(name: name, identifier: identifier)
+                session.user.devices.append(device)
+            }
+        }
+        .navigationTitle("Add Device")
+    }
+}
+
+struct AddDeviceView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            AddDeviceView()
+                .environmentObject(UserSession(user: User(email: "", password: "", locations: [], devices: [])))
+        }
+    }
+}

--- a/SmartPlantPotApp/DashboardView.swift
+++ b/SmartPlantPotApp/DashboardView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct DashboardView: View {
+    @EnvironmentObject var session: UserSession
     @State private var plants: [Plant] = []
 
     var body: some View {
@@ -14,6 +15,11 @@ struct DashboardView: View {
             }
             .navigationTitle("My Plants")
             .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    NavigationLink(destination: DeviceManagementView()) {
+                        Image(systemName: "bolt.horizontal" )
+                    }
+                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     NavigationLink(destination: AddPlantView(plants: $plants)) {
                         Image(systemName: "plus")
@@ -27,5 +33,6 @@ struct DashboardView: View {
 struct DashboardView_Previews: PreviewProvider {
     static var previews: some View {
         DashboardView()
+            .environmentObject(UserSession(user: User(email: "", password: "", locations: [], devices: [])))
     }
 }

--- a/SmartPlantPotApp/DeviceManagementView.swift
+++ b/SmartPlantPotApp/DeviceManagementView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct DeviceManagementView: View {
+    @EnvironmentObject var session: UserSession
+
+    var body: some View {
+        List {
+            ForEach(session.user.devices) { device in
+                Text(device.name)
+            }
+        }
+        .navigationTitle("Devices")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                NavigationLink(destination: AddDeviceView()) {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+    }
+}
+
+struct DeviceManagementView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            DeviceManagementView()
+                .environmentObject(UserSession(user: User(email: "", password: "", locations: [], devices: [])))
+        }
+    }
+}

--- a/SmartPlantPotApp/LoginView.swift
+++ b/SmartPlantPotApp/LoginView.swift
@@ -3,6 +3,7 @@ import GoogleSignIn
 import GoogleSignInSwift
 
 struct LoginView: View {
+    @EnvironmentObject var session: UserSession
     @State private var email: String = ""
     @State private var password: String = ""
     @State private var isLoggedIn: Bool = false
@@ -10,6 +11,7 @@ struct LoginView: View {
     var body: some View {
         if isLoggedIn {
             DashboardView()
+                .environmentObject(session)
         } else {
             VStack {
                 Text("Smart Plant Pot").font(.largeTitle)
@@ -21,6 +23,7 @@ struct LoginView: View {
                     .padding()
                 Button("Login") {
                     // TODO: Implement real authentication
+                    session.user.email = email
                     isLoggedIn = true
                 }
                 .padding()
@@ -45,5 +48,6 @@ struct LoginView: View {
 struct LoginView_Previews: PreviewProvider {
     static var previews: some View {
         LoginView()
+            .environmentObject(UserSession(user: User(email: "", password: "", locations: [], devices: [])))
     }
 }

--- a/SmartPlantPotApp/Models.swift
+++ b/SmartPlantPotApp/Models.swift
@@ -5,6 +5,17 @@ struct User: Identifiable {
     var email: String
     var password: String
     var locations: [Location]
+    /// Devices linked to this user account
+    var devices: [Device]
+}
+
+/// Represents a physical sensor device that can upload data for the user.
+struct Device: Identifiable {
+    let id = UUID()
+    /// Friendly name chosen by the user
+    var name: String
+    /// Unique identifier from the hardware (e.g. serial number)
+    var identifier: String
 }
 
 struct Location: Identifiable {

--- a/SmartPlantPotApp/SmartPlantPotApp.swift
+++ b/SmartPlantPotApp/SmartPlantPotApp.swift
@@ -2,9 +2,12 @@ import SwiftUI
 
 @main
 struct SmartPlantPotApp: App {
+    @StateObject private var session = UserSession(user: User(email: "", password: "", locations: [], devices: []))
+
     var body: some Scene {
         WindowGroup {
             LoginView()
+                .environmentObject(session)
         }
     }
 }

--- a/SmartPlantPotApp/UserSession.swift
+++ b/SmartPlantPotApp/UserSession.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Global session object that stores the authenticated user's information
+/// and linked devices.
+class UserSession: ObservableObject {
+    @Published var user: User
+
+    init(user: User) {
+        self.user = user
+    }
+}


### PR DESCRIPTION
## Summary
- support linking hardware devices to user accounts using a shared session
- update Dashboard, AddDeviceView and DeviceManagementView to use the session
- pass the session through LoginView and the main app

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_684761a2db6c832891bd8b497985ee3a