### PR TITLE
Use AWS IoT for ESP32 data persistence

### DIFF
--- a/ESP32Firmware/README.md
+++ b/ESP32Firmware/README.md
@@ -1,6 +1,6 @@
 # ESP32 Smart Plant Pot Firmware
 
-This firmware reads environmental values from several sensors connected to an ESP32 board and displays them on a 1.8" ST7735 screen. It also posts sensor values once per hour (at minute 1) to a DynamoDB-backed endpoint.
+This firmware reads environmental values from several sensors connected to an ESP32 board and displays them on a 1.8" ST7735 screen. It also publishes sensor values every hour (at minute 1) to AWS IoT so they can be persisted to DynamoDB via an IoT rule.
 
 ## Features
 
@@ -9,16 +9,16 @@ This firmware reads environmental values from several sensors connected to an ES
   - AHT10 temperature and humidity sensor over I2C
   - LDR for ambient light (analog pin 35)
 - **Display**: ST7735 1.8" color display
-- **Data Upload**: Sends JSON data to a web API (such as an AWS API Gateway backed by DynamoDB) every hour when the minute equals 1.
+- **Data Upload**: Publishes JSON to AWS IoT every hour when the minute equals 1. Configure an IoT rule to store these messages in DynamoDB.
 - **Time**: Obtains current time via NTP to schedule hourly uploads.
 
 ## Usage
 
-1. Install libraries for `Adafruit_ST7735`, `Adafruit_GFX`, and `Adafruit_AHTX0` via the Arduino Library Manager.
-2. Set your Wi-Fi credentials and the API endpoint URL in `ESP32SmartPlantPot.ino`.
+1. Install libraries for `Adafruit_ST7735`, `Adafruit_GFX`, `Adafruit_AHTX0` and `AWS_IOT` via the Arduino Library Manager.
+2. Set your Wi-Fi credentials, AWS IoT endpoint, client ID and certificates in `ESP32SmartPlantPot.ino`.
 3. Build and flash the sketch to an ESP32 using the Arduino IDE or PlatformIO.
 
-Sensor readings are refreshed every second on the display. Data will be persisted to the remote endpoint once per hour.
+Sensor readings are refreshed every second on the display. Data will be published to AWS IoT once per hour.
 
 ## Hardware wiring
 


### PR DESCRIPTION
## Summary
- use `AWS_IOT` library instead of HTTP client
- publish sensor data to AWS IoT via MQTT
- describe new AWS IoT usage in firmware README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847d4875d5083288ff461b4af88d598